### PR TITLE
Recursively create config directory.

### DIFF
--- a/fac/files.py
+++ b/fac/files.py
@@ -72,7 +72,7 @@ class Config(ConfigParser):
         dirname = os.path.dirname(self.config_file)
 
         if not os.path.isdir(dirname):
-            os.mkdir(dirname)
+            os.makedirs(dirname)
 
         with open(self.config_file, 'w', encoding='utf-8') as f:
             self.write(f)


### PR DESCRIPTION
A brand new linux user account may not have a .config directory
at all. Trying to create a 'fac' subdirectory using os.mkdir
results in a FileNotFoundException.