### PR TITLE
Add -y flag to update and remove commands.

### DIFF
--- a/fac/commands/remove.py
+++ b/fac/commands/remove.py
@@ -8,6 +8,9 @@ class RemoveCommand(Command):
     name = 'remove'
     arguments = [
         Arg('mod', help="Mod pattern to remove ('*' for all)", nargs='+'),
+
+        Arg('-y', '--yes', action='store_true',
+            help='automatic yes to confirmation prompt'),
     ]
 
     def run(self, args):
@@ -19,7 +22,7 @@ class RemoveCommand(Command):
             print('The following files will be removed:')
             for file in files:
                 print('    %s' % file)
-            if prompt('Continue?', 'Y/n') != 'y':
+            if not args.yes and prompt('Continue?', 'Y/n') != 'y':
                 return
 
             for mod_name in args.mod:

--- a/fac/commands/update.py
+++ b/fac/commands/update.py
@@ -13,6 +13,9 @@ class UpdateCommand(Command):
         Arg('-s', '--show', action='store_true',
             help='only show what would be updated'),
 
+        Arg('-y', '--yes', action='store_true',
+            help='automatic yes to confirmation prompt'),
+
         Arg('--force', action='store_true',
             help='force update of held mods'),
     ]
@@ -63,7 +66,7 @@ class UpdateCommand(Command):
             ))
 
         if not args.show:
-            if prompt('Continue?', 'Y/n') != 'y':
+            if not args.yes and prompt('Continue?', 'Y/n') != 'y':
                 return
 
             for local_mod, release in updates:


### PR DESCRIPTION
This allows the confirmation prompts to be skipped (in the same
manner as apt-get's -y flag).

This is desirable if fac is being used from a script where there
is no user input (for example an automatic updater or a new
server installation script).